### PR TITLE
Don't require import of debug_here to use the macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use nix::unistd;
 #[macro_export]
 macro_rules! debug_here {
     () => {
-        debug_here::debug_here_impl();
+        ::debug_here::debug_here_impl();
     }
 }
 


### PR DESCRIPTION
Multi-file projects should not require you to `use debug_here` in your code to use the macro.