### PR TITLE
add macos support

### DIFF
--- a/debug-me/src/main.rs
+++ b/debug-me/src/main.rs
@@ -4,6 +4,13 @@ mod another_module;
 
 fn factorial(n: usize) -> usize {
     let mut res = 1;
+    // Try changing the debugger backend by replacing this with
+    //
+    // debug_here!(lldb);
+    //
+    // or
+    //
+    // debug_here!(gdb);
     debug_here!();
     for i in 0..n {
         res *= i;


### PR DESCRIPTION
This patch adds support for using debug-here on macos. In order
to do so, we also add support for using rust-lldb as a debugger
backend because Apple ships lldb with macos but not gdb, and
giving a program rights to debug something on macos is kind
of a hassle.

We introduce a new syntax for selecting the debugger backend.

```rust
debug_here!() // pop open a debugger with the default backend (lldb on
              // mac, gdb on linux)
debug_here!(gdb) // pop open a debugger with rust-gdb
debug_here!(lldb) // pop open a debugger with rust-lldb
```

This functionality works just as well on Linux as it does on macos.

In order to support using an lldb backend on linux, we introduce
a new debug-here-gdb-wrapper protocol (bumping the version number
to 2). This new version is only used when trying to open an lldb
debugger, so people who have already installed debug-here-gdb-wrapper
won't have anything broken (it may be kind of silly to pretend that I
have users, but I'm doing it anyway).

The README is updated to reflect the new changes.

Closes #3